### PR TITLE
Fix 0.7 deprecations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: julia
 notifications:
   email: false
 julia:
-  - 0.3
-  - 0.4
+  - 0.6
+  - 0.7
   - nightly
 #script:
 #  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
 julia 0.3
-Compat
+Compat 0.41

--- a/src/CPUTime.jl
+++ b/src/CPUTime.jl
@@ -12,7 +12,7 @@ export
 
 function CPUtime_us()
     @compat rusage = Libc.malloc(4*sizeof(Clong) + 14*sizeof(UInt64))  # sizeof(uv_rusage_t); this is different from sizeof(rusage)
-    ccall(:uv_getrusage, Cint, (Ptr{Void},), rusage)
+    ccall(:uv_getrusage, Cint, (Ptr{Nothing},), rusage)
     @compat utime = UInt64(1000000)*unsafe_load(convert(Ptr{Clong}, rusage + 0*sizeof(Clong))) +    # user CPU time
                                     unsafe_load(convert(Ptr{Clong}, rusage + 1*sizeof(Clong)))
     @compat stime = UInt64(1000000)*unsafe_load(convert(Ptr{Clong}, rusage + 2*sizeof(Clong))) +    # system CPU time

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using CPUTime
-using Base.Test
+using Compat.Test
 
 function add_and_sleep()
     x = 0
@@ -10,12 +10,12 @@ function add_and_sleep()
 end
 
 function time_difference()
-    tic()
-    CPUtic()
-    add_and_sleep()
-    return toq() - CPUtoq()
+    dt = @elapsed begin
+        CPUdt = @CPUelapsed add_and_sleep()
+    end
+    return dt - CPUdt
 end
 
 time_difference()  # compilation overhead should not affect results, but just in case
 time_diff = time_difference()
-eval(parse("@test abs($time_diff - 1.0) <= .01"))
+eval(Meta.parse("@test abs($time_diff - 1.0) <= .01"))


### PR DESCRIPTION
Fix 0.7 deprecations; leaving CPUtic/CPUtoc/CPUtoq though their counterparts were deprecated in Base.

TBD how many of the tests in `.travis.yml` still work.
```
 julia:
   - 0.3
   - 0.4
   - 0.5
   - 0.6
   - 0.7
   - nightly
```